### PR TITLE
Handle scientific notation floats

### DIFF
--- a/src/prometheus.pest
+++ b/src/prometheus.pest
@@ -209,11 +209,11 @@ expression = {
 duration_value = ${ ASCII_DIGIT+ }
 duration_unit = ${ "s" | "m" | "h" | "d" | "w" | "y" }
 
-// allow 1, 1.0, -1, -1.0, .1, -.1 but don't allow empty / '.' / '-' / '-.'
+// allow 1, 1.0, -1, -1.0, .1, -.1, 1e1, -1e1, 1e-1, -1e-1 but don't allow empty / '.' / '-' / '-.'
 signed_float = @{
   ("+" | "-")? ~ (
     ("Inf" | "NaN") |
-    (ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)?) |
+    (ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?) |
     ("." ~ ASCII_DIGIT+)
   )
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -504,3 +504,43 @@ fn parse_weird_floats() -> Result<()> {
 
   Ok(())
 }
+
+#[test]
+fn parse_scientific_notation_floats() -> Result<()> {
+    match parse_expr("1e1")? {
+      Expression::Float(f) => assert_eq!(f, (1e1 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("1e-1")? {
+      Expression::Float(f) => assert_eq!(f, (1e-1 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("-1e1")? {
+      Expression::Float(f) => assert_eq!(f, (-1e1 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("-1e-1")? {
+      Expression::Float(f) => assert_eq!(f, (-1e-1 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("1.0e1")? {
+      Expression::Float(f) => assert_eq!(f, (1.0e1 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("1e01")? {
+      Expression::Float(f) => assert_eq!(f, (1e01 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    match parse_expr("1E01")? {
+      Expression::Float(f) => assert_eq!(f, (1e01 as f64)),
+      _ => assert!(false, "must be a float")
+    };
+
+    Ok(())
+}


### PR DESCRIPTION
Hi! I've been using this project to write some Prometheus tooling at the company I work for and ran into an issue where the parser doesn't support scientific notation. Reading the Prometheus docs expressions are allowed to have scientific notation (https://prometheus.io/docs/prometheus/latest/querying/basics/#float-literals) so I've updated the grammar to handle it.

Thanks for a super useful project and one that was easy to dive in to when I found a problem.