### PR TITLE
Properly quote string arguments when displaying  functions

### DIFF
--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -372,8 +372,11 @@ impl fmt::Display for Function {
             if i > 0 {
                 write!(f, ", ")?;
             }
-
-            write!(f, "{}", arg)?;
+            if let Expression::String(s) = &**arg {
+                write!(f, "\"{}\"", s)?
+            } else {
+                write!(f, "{}", arg)?
+            };
         }
 
         write!(f, ")")?;


### PR DESCRIPTION
The Display implementation for Function is not properly quoting string arguments.
For example, doing `parse_expr()` on this query:
```
label_replace(metric{label1="value1",label2="value2",label3=~"value3.*"}, "new_label", "$1", "label3", ".*(([0-9]+)).*")
```
results in this:
```
label_replace(metric{label1="value1",label2="value2",label3=~"value3.*"}, new_label, $1, label3, .*(([0-9]+)).*)
```
And with the unquoted arguments, especially the regex reference $1 this fails to parse.

With this change the result is this:
```
label_replace(metric{label1="value1",label2="value2",label3=~"value3.*"}, "new_label", "$1", "label3", ".*(([0-9]+)).*")
```